### PR TITLE
Consider locale when looking for redirects.

### DIFF
--- a/ndp-check-redirects/index.js
+++ b/ndp-check-redirects/index.js
@@ -48,8 +48,8 @@ Toolkit.run(async tools => {
       }
 
       changedFiles.push({
-        from: pathToUrl(file.previous_filename),
-        to: pathToUrl(file.filename)
+        from: file.previous_filename,
+        to: pathToUrl(file.filename),
       });
     }
 
@@ -60,7 +60,7 @@ Toolkit.run(async tools => {
       }
 
       changedFiles.push({
-        from: pathToUrl(file.filename),
+        from: file.filename,
         to: 'MISSING'
       });
     }
@@ -80,17 +80,17 @@ Toolkit.run(async tools => {
     const errors = [];
     const foundRedirects = {};
     for (let change of changedFiles) {
-      if (!redirects[change.from]) {
-        errors.push(`"${change.from}": "${change.to}"`);
+      if (!redirects[pathToUrl(change.from)]) {
+        errors.push(`"${pathToUrl(change.from)}": "${change.to}"`);
       } else {
-        foundRedirects[change.from] = redirects[change.from];
+        foundRedirects[change.from] = redirects[pathToUrl(change.from)];
       }
     }
     tools.log.complete('Checking if redirects exist');
 
     // If there is a redirect, make sure that the new destination exists
     for (let f in foundRedirects) {
-      let path = `${tools.workspace}/_documentation${foundRedirects[f]}.md`
+      let path = `${tools.workspace}/_documentation/${getLocaleFromPath(f)}${foundRedirects[f]}.md`
 
       let missing = true;
 
@@ -121,6 +121,10 @@ Toolkit.run(async tools => {
     tools.exit.success('No missing redirects');
   }
 }, { event: 'pull_request' })
+
+function getLocaleFromPath(path) {
+  return path.substr(15, 2);
+}
 
 function pathToUrl(path) {
     return path.substr(17).slice(0, -3);

--- a/ndp-check-redirects/index.test.js
+++ b/ndp-check-redirects/index.test.js
@@ -98,6 +98,9 @@ describe("Check Redirects Action", () => {
 
         await action(tools);
 
+        expect(fs.existsSync.mock.calls[0][0]).toBe("/tmp/_documentation/cn/file1.md");
+        expect(fs.existsSync.mock.calls[1][0]).toBe("/tmp/_documentation/en/client-sdk/file3.md");
+        expect(fs.existsSync.mock.calls[2][0]).toBe("/tmp/_documentation/en/file1.md");
         expect(tools.log.warn).toHaveBeenCalledWith("Ignorning renamed file not in _documentation folder: ignored_old.md");
         expect(tools.log.warn).toHaveBeenCalledWith("Ignorning deleted file not in _documentation folder: removed.md");
         expect(tools.getFile).toHaveBeenCalledWith("config/redirects.yml");
@@ -159,9 +162,9 @@ describe("Check Redirects Action", () => {
         expect(tools.exit.failure).toHaveBeenCalledWith(
           `Missing redirects: 
 
-Specified redirect could not be found: /tmp/_documentation/file1-invalid.md
-Specified redirect could not be found: /tmp/_documentation/client-sdk/file3-invalid.md
-Specified redirect could not be found: /tmp/_documentation/file2-invalid.md`
+Specified redirect could not be found: /tmp/_documentation/cn/file1-invalid.md
+Specified redirect could not be found: /tmp/_documentation/en/client-sdk/file3-invalid.md
+Specified redirect could not be found: /tmp/_documentation/en/file2-invalid.md`
       );
       });
     });


### PR DESCRIPTION
* Include locale when searching for the file corresponding to the found
redirect
* Include locale in error messages.