### PR TITLE
OpenAPI Release: Increase resilience when provided with invalid data

### DIFF
--- a/openapi-release/index.js
+++ b/openapi-release/index.js
@@ -41,6 +41,11 @@ Toolkit.run(async tools => {
 
   tools.log.debug(`Latest tag commit hash: ${before}`);
 
+  if (!/[0-9a-f]{40}/.test(before)) {
+    tools.exit.failure("A manual release has been created with a target_commitish that is not a sha. Unable to proceed");
+    return;
+  }
+
   tools.log.debug(`Generating diff since that commit`);
   tools.log.debug(`From: ${before}`);
   tools.log.debug(`To: ${commit_sha}`);
@@ -123,6 +128,10 @@ Toolkit.run(async tools => {
     return;
   }
 
+  // If any of the versions are quoted in strings, remove those
+  fromVersion = stripQuotes(fromVersion);
+  toVersion = stripQuotes(toVersion);
+
   // Make sure the version number went upwards
   if (semver.gt(fromVersion, toVersion)) {
     tools.exit.failure(
@@ -194,3 +203,18 @@ Toolkit.run(async tools => {
     return;
   }
 });
+
+function stripQuotes(str) {
+  let first = str[0];
+  let last = str[str.length-1];
+
+  if (first == '"' && last == '"'){
+    return str.slice(1,-1);
+  }
+
+  if (first == "'" && last == "'"){
+    return str.slice(1,-1);
+  }
+
+  return str;
+}

--- a/openapi-release/index.test.js
+++ b/openapi-release/index.test.js
@@ -49,6 +49,23 @@ describe("OAS Release Action", () => {
   });
 
   describe("Change detection", () => {
+    it("exits if a non-sha target_committish is returned", async () => {
+      let owner = tools.context.payload.repository.owner.name;
+      let repo = tools.context.payload.repository.name;
+
+      nock("https://api.github.com")
+        .get(`/repos/${owner}/${repo}/releases?per_page=1&page=1`)
+        .reply(200, [
+          { target_commitish: "master" }
+        ]);
+
+      tools.exit.failure = jest.fn();
+      await action(tools);
+      expect(tools.exit.failure).toHaveBeenCalledWith(
+        "A manual release has been created with a target_commitish that is not a sha. Unable to proceed"
+      );
+    });
+
     it("exits with files with no version changes", async () => {
       let owner = tools.context.payload.repository.owner.name;
       let repo = tools.context.payload.repository.name;


### PR DESCRIPTION
If a manual release is created with a `target_commitish` of `master`, it
will compare `HEAD` with `master`, which contains no changes and never
trigger a release.

In addition, some OpenAPI docs contain version numbers that the semver
library does not parse. We now sanitise these inputs before version
comparison