### PR TITLE
Adding Nuget auto-release action 

### DIFF
--- a/nuget-release/Dockerfile
+++ b/nuget-release/Dockerfile
@@ -1,0 +1,32 @@
+# Use the latest version of Node.js
+#
+# You may prefer the full image:
+# FROM node
+#
+# or even an alpine image (a smaller, faster, less-feature-complete image):
+# FROM node:alpine
+#
+# You can specify a version:
+FROM mcr.microsoft.com/dotnet/sdk:5.0
+
+# Labels for GitHub to read your action
+LABEL "com.github.actions.name"="Publish release to NuGet"
+LABEL "com.github.actions.description"="When a new release is tagged - update the csproj file of the project to the tagged version, and publish a new release."
+# Here are all of the available icons: https://feathericons.com/
+LABEL "com.github.actions.icon"="tag"
+# And all of the available colors: https://developer.github.com/actions/creating-github-actions/creating-a-docker-container/#label
+LABEL "com.github.actions.color"="blue"
+
+# Copy the package.json and package-lock.json
+COPY package*.json ./
+
+# Install dependencies
+RUN apt-get update
+RUN apt-get install nodejs -y
+RUN apt-get install npm -y
+RUN npm ci
+
+# Copy the rest of your action's code
+COPY . .
+
+ENTRYPOINT ["node", "/index.js"]

--- a/nuget-release/README.md
+++ b/nuget-release/README.md
@@ -1,0 +1,52 @@
+# NuGet Auto-Release Action
+
+This action is meant to allow the maintainer of a .NET repository automatically release their NuGet package when a new release is cut in GitHub.
+
+## Prerequisites
+
+* You'll need a NuGet Account, from which you'll need to obtain your account's [NuGet Api Key](https://www.nuget.org/account/apikeys) The account will have to be an owner of the NuGet package that it seeks to publish.
+
+## Example usage
+
+```yml
+name: Nuget Release
+
+on:
+  release:
+    types: [published]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.release.target_commitish }}      
+      - name: Release Nuget
+        uses: nexmo/github-actions/nuget-release@master
+        env:
+          PROJECT_FILE : NugetActionTest.csproj          
+          BRANCH: main
+          ORGANIZATION: ORG_NAME
+          REPO: test-nuget-action
+          TAG: ${{ github.event.release.tag_name }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+          GITHUB_USER_NAME: USER_NAME
+          GITHUB_EMAIL: USER_EMAIL
+```
+
+## Args
+
+| Arg name | Description |
+| -------- | ---------- |
+| PROJECT_FILE | The csproj file from which the nuget package will be built and released |
+| BRANCH | The branch that you release off of. The csproj file will be updated and pushed back to your release branch. The tag will then be moved back to the branch|
+| ORGANIZATION | The orginization your repo is in |
+| REPO | the name of your repository |
+| GITHUB_TOKEN | use `${{ secrets.GITHUB_TOKEN }}` |
+| NUGET_API_KEY | your API key from NuGet - it is strongly advised that you add this to your repo's secrets and use it from there. |
+| GITHUB_USER_NAME | Your github username |
+| GITHUB_EMAIL| Your github email |
+| TAG | Your releases tag - must use `${{ github.event.release.tag_name }}` |
+
+> NOTE: TAG must be in the form of `vX.Y.Z` where X = major version, Y = minor Version, Z = patch version.

--- a/nuget-release/action.yml
+++ b/nuget-release/action.yml
@@ -1,0 +1,9 @@
+name: 'Publish release to NuGet'
+description: 'When a new release is tagged - update the csproj file of the project to the tagged version, and publish a new release.'
+author: 'Stephen Lorello'
+branding:
+  icon: 'search'
+  color: 'orange'
+runs:
+  using: docker
+  image: Dockerfile  

--- a/nuget-release/index.js
+++ b/nuget-release/index.js
@@ -1,0 +1,95 @@
+const os = require("os"),
+    fs = require("fs"),
+    path = require("path"),
+    https = require("https"),
+    xml2js = require("xml2js"),
+    parseString = require("xml2js").parseString,
+    spawnSync = require("child_process").spawnSync;
+
+class Action{
+    constructor(){
+        this.projectFile = process.env.PROJECT_FILE;
+        this.packageName = process.env.PACKAGE_NAME;
+        this.version = process.env.TAG.substring(1);
+        this.branch = process.env.BRANCH;
+        this.organization = process.env.ORGANIZATION;
+        this.repo = process.env.REPO;
+        this.tag = process.env.TAG;
+        this.nuget_api_key = process.env.NUGET_API_KEY;
+        this.github_user_name = process.env.GITHUB_USER_NAME;
+        this.github_email = process.env.GITHUB_EMAIL;
+        this._executeCommand(`git config --global user.name "${this.github_user_name}"`);
+        this._executeCommand(`git config --global user.email "${this.github_email}"`);
+        this._executeCommand(`git config --global github.token ${process.env.GITHUB_TOKEN}`);
+    }
+
+    _executeCommand(cmd, options) {
+        console.log(`executing: [${cmd}]`)
+        let ops = {
+            cwd: process.cwd(),
+            env: process.env,
+            stdio: 'pipe',
+            encoding: 'utf-8'            
+        };
+        const INPUT = cmd.split(" "), TOOL = INPUT[0], ARGS = INPUT.slice(1)        
+        console.log(String(spawnSync(TOOL, ARGS, ops).output));
+    }
+
+    _executeCommandWithArgs(cmd, args){
+        console.log(`executing: [${cmd}]`)
+        let ops = {
+            cwd: process.cwd(),
+            env: process.env,
+            stdio: 'pipe',
+            encoding: 'utf-8'            
+        };
+        console.log(String(spawnSync(cmd, args, ops).output));
+    }
+
+    _runRelease(){
+        fs.readFile(this.projectFile,"utf-8", (err, data)=>{
+            if(err) {
+                console.log(err);                
+            }
+            else {
+                parseString(data, (err,result)=>{
+                    if(err) {
+                        console.log(err);                        
+                    }                
+                    else{
+                        let json = result;
+                        console.log(json.Project.PropertyGroup);
+                        json.Project.PropertyGroup[0].Version[0] = this.version;
+                        json.Project.PropertyGroup[0].PackageReleaseNotes[0]=`https://github.com/${this.organization}/${this.repo}/releases/tag/v${this.version}`
+                        var builder = new xml2js.Builder();
+                        var xml = builder.buildObject(json);
+                        fs.writeFile(this.projectFile, xml, (err,res)=>{
+                            if (err) console.log(err);
+                            else {
+                                console.log("Successfully wrote out to xml file");
+                                this._executeCommand(`git add ${this.projectFile}`);
+                                this._executeCommandWithArgs(`git`, ["commit", "-m", `'Bumping version to ${this.version}'`]);
+                                this._executeCommand(`git push`);
+                                this._executeCommand(`git tag -f ${this.tag}`);
+                                this._executeCommand(`git push origin ${this.tag} --force`);
+                                this._executeCommand(`dotnet build -c Release ${this.projectFile}`);
+                                this._executeCommand(`dotnet pack -c Release ${this.projectFile}`);
+                                this._executeCommand(`dotnet nuget push bin/Release/*.${this.version}.nupkg -s https://api.nuget.org/v3/index.json -k ${this.nuget_api_key}`)
+                            }
+                        });
+                    }                    
+                });
+            }
+        })
+    }    
+    run(){
+        console.log("Hello world");
+        if (!fs.existsSync(this.projectFile)){            
+            console.log("File not Found")            
+        }
+        else{
+            this._runRelease(); 
+        }
+    }
+}
+new Action().run();

--- a/nuget-release/package-lock.json
+++ b/nuget-release/package-lock.json
@@ -1,0 +1,32 @@
+{
+  "name": "nuget-release",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "child_process": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/child_process/-/child_process-1.0.2.tgz",
+      "integrity": "sha1-sffn/HPSXn/R1FWtyU4UODAYK1o="
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
+    "xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      }
+    },
+    "xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
+    }
+  }
+}

--- a/nuget-release/package.json
+++ b/nuget-release/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "nuget-release",
+  "version": "1.0.0",
+  "description": "On a newly tagged release in github, updates csproj file, moves release tags, and pushes release out to nuget.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Steve Lorello",
+  "license": "MIT",
+  "dependencies": {
+    "child_process": "^1.0.2",
+    "xml2js": "^0.4.23"
+  }
+}


### PR DESCRIPTION
New Github action to allow the automatic release of NuGet packages when a new release is cut in Github. For instructions for usage see the README - for an example of it being used see https://github.com/slorello89/test-nuget-action