### PR TITLE
Add safe directory command for nuget-release

### DIFF
--- a/nuget-release/index.js
+++ b/nuget-release/index.js
@@ -23,6 +23,7 @@ class Action{
         this._executeCommand(`git config --global user.name "${this.github_user_name}"`);
         this._executeCommand(`git config --global user.email "${this.github_email}"`);
         this._executeCommand(`git config --global github.token ${process.env.GITHUB_TOKEN}`);
+        this._executeCommand(`git config --global --add safe.directory /github/workspace`);
     }
 
     _executeCommand(cmd, options) {


### PR DESCRIPTION
NuGet release action started to fail recently. The NuGet is still created and pushed, but actions on the repo aren't successful (create tag, bump version, merge back to main).
This PR is about adding an exception for the current directory.

![image](https://user-images.githubusercontent.com/59444272/225598493-303d8c44-4031-4cd2-9398-83995137409b.png)
